### PR TITLE
chore: remove fmt.Println from liquidity_pool and swap files

### DIFF
--- a/x/liquidity/keeper/liquidity_pool.go
+++ b/x/liquidity/keeper/liquidity_pool.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/tendermint/liquidity/x/liquidity/types"
@@ -177,7 +176,6 @@ func (k Keeper) CreateLiquidityPool(ctx sdk.Context, msg *types.MsgCreateLiquidi
 	lastReserveRatio := sdk.NewDecFromInt(reserveCoins[0].Amount).Quo(sdk.NewDecFromInt(reserveCoins[1].Amount))
 	logger := k.Logger(ctx)
 	logger.Info("createPool", msg, "pool", liquidityPool, "reserveCoins", reserveCoins, "lastReserveRatio", lastReserveRatio)
-	fmt.Println("createPool", msg, "pool", liquidityPool, "reserveCoins", reserveCoins, "lastReserveRatio", lastReserveRatio)
 	return nil
 }
 
@@ -358,7 +356,6 @@ func (k Keeper) DepositLiquidityPool(ctx sdk.Context, msg types.BatchPoolDeposit
 	lastReserveRatio = sdk.NewDecFromInt(reserveCoins[0].Amount).Quo(sdk.NewDecFromInt(reserveCoins[1].Amount))
 	logger := k.Logger(ctx)
 	logger.Info("deposit", msg, "pool", pool, "inputs", inputs, "outputs", outputs, "reserveCoins", reserveCoins, "lastReserveRatio", lastReserveRatio)
-	fmt.Println("deposit", msg, "pool", pool, "inputs", inputs, "outputs", outputs, "reserveCoins", reserveCoins, "lastReserveRatio", lastReserveRatio)
 	return nil
 }
 
@@ -441,7 +438,6 @@ func (k Keeper) WithdrawLiquidityPool(ctx sdk.Context, msg types.BatchPoolWithdr
 		lastReserveRatio := sdk.NewDecFromInt(reserveCoins[0].Amount).Quo(sdk.NewDecFromInt(reserveCoins[1].Amount))
 		logger := k.Logger(ctx)
 		logger.Info("withdraw", msg, "pool", pool, "inputs", inputs, "outputs", outputs, "reserveCoins", reserveCoins, "lastReserveRatio", lastReserveRatio)
-		fmt.Println("withdraw", msg, "pool", pool, "inputs", inputs, "outputs", outputs, "reserveCoins", reserveCoins, "lastReserveRatio", lastReserveRatio)
 	}
 	return nil
 }

--- a/x/liquidity/keeper/swap.go
+++ b/x/liquidity/keeper/swap.go
@@ -47,10 +47,8 @@ func (k Keeper) SwapExecution(ctx sdk.Context, liquidityPoolBatch types.Liquidit
 
 	// check orderbook validity and compute batchResult(direction, swapPrice, ..)
 	result := types.MatchOrderbook(X, Y, currentYPriceOverX, orderBook)
-	fmt.Println("batch Result before", result)
 
 	// find order match, calculate pool delta with the total x, y amount for the invariant check
-	fmt.Println("before XtoY, YtoX", len(XtoY), len(YtoX))
 	beforeXtoYLen := len(XtoY)
 	beforeYtoXLen := len(YtoX)
 	var matchResultXtoY, matchResultYtoX []types.MatchResult
@@ -70,9 +68,7 @@ func (k Keeper) SwapExecution(ctx sdk.Context, liquidityPoolBatch types.Liquidit
 		k.UpdateState(X, Y, XtoY, YtoX, matchResultXtoY, matchResultYtoX)
 
 	lastPrice := X.Quo(Y)
-	fmt.Println("lastPrice ", lastPrice)
 
-	fmt.Println("result.SwapPrice, X, Y, currentYPriceOverX", result.SwapPrice, X, Y, currentYPriceOverX)
 	if beforeXtoYLen-len(matchResultXtoY)+fractionalCntX != (types.MsgList)(XtoY).CountNotMatchedMsgs()+(types.MsgList)(XtoY).CountFractionalMatchedMsgs() {
 		panic(beforeXtoYLen)
 	}
@@ -84,7 +80,6 @@ func (k Keeper) SwapExecution(ctx sdk.Context, liquidityPoolBatch types.Liquidit
 	totalAmtY := sdk.ZeroInt()
 
 	for _, mr := range matchResultXtoY {
-		fmt.Println("matchResultXtoY", mr)
 		totalAmtX = totalAmtX.Sub(mr.TransactedCoinAmt)
 		totalAmtY = totalAmtY.Add(mr.ExchangedDemandCoinAmt)
 	}
@@ -96,7 +91,6 @@ func (k Keeper) SwapExecution(ctx sdk.Context, liquidityPoolBatch types.Liquidit
 	totalAmtY = sdk.ZeroInt()
 
 	for _, mr := range matchResultYtoX {
-		fmt.Println("matchResultYtoX", mr)
 		totalAmtY = totalAmtY.Sub(mr.TransactedCoinAmt)
 		totalAmtX = totalAmtX.Add(mr.ExchangedDemandCoinAmt)
 	}
@@ -109,25 +103,9 @@ func (k Keeper) SwapExecution(ctx sdk.Context, liquidityPoolBatch types.Liquidit
 
 	// print the invariant check and validity with swap, match result
 	if invariantCheckX.IsZero() && invariantCheckY.IsZero() {
-		fmt.Println("swap execution invariant check: True")
 	} else {
-		fmt.Println("swap execution invariant check: False", invariantCheckX, invariantCheckY)
 		panic(invariantCheckX)
 	}
-
-	if result.MatchType == 1 {
-		fmt.Println("matchType: ", "ExactMatch")
-	} else if result.MatchType == 2 {
-		fmt.Println("matchType: ", "No Match")
-	} else if result.MatchType == 3 {
-		fmt.Println("matchType: ", "FractionalMatch")
-	}
-
-	fmt.Println("swapPrice: ", result.SwapPrice)
-	fmt.Println("matchResultXtoY: ", matchResultXtoY)
-	fmt.Println("matchResultYtoX: ", matchResultYtoX)
-	fmt.Println("matched totalAmtX, totalAmtY", totalAmtX, totalAmtY)
-	fmt.Println("poolXdelta, poolYdelta", poolXdelta, poolYdelta, poolXdelta2, poolYdelta2)
 
 	if !poolXdelta.Add(decimalErrorX).Equal(poolXdelta2) || !poolYdelta.Add(decimalErrorY).Equal(poolYdelta2) {
 		panic(poolXdelta)
@@ -138,12 +116,7 @@ func (k Keeper) SwapExecution(ctx sdk.Context, liquidityPoolBatch types.Liquidit
 
 	orderMapExecuted, _, _ := types.GetOrderMap(append(XtoY, YtoX...), denomX, denomY, true)
 	orderBookExecuted := orderMapExecuted.SortOrderBook()
-	fmt.Println("orderbook after batch")
 	orderBookValidity := types.CheckValidityOrderBook(orderBookExecuted, lastPrice)
-	for _, v := range orderBookExecuted {
-		fmt.Println(v)
-	}
-	fmt.Println("orderBookValidity:", orderBookValidity)
 	if !orderBookValidity {
 		fmt.Println(orderBookValidity, "ErrOrderBookInvalidity")
 		panic(types.ErrOrderBookInvalidity)
@@ -151,7 +124,6 @@ func (k Keeper) SwapExecution(ctx sdk.Context, liquidityPoolBatch types.Liquidit
 
 	// TODO: WIP new validity
 	validitySwapPrice := types.CheckSwapPrice(matchResultXtoY, matchResultYtoX, result.SwapPrice)
-	fmt.Println("validitySwapPrice:", validitySwapPrice)
 	if !validitySwapPrice {
 		panic("validitySwapPrice")
 	}
@@ -296,9 +268,6 @@ func (k Keeper) UpdateState(X, Y sdk.Dec, XtoY, YtoX []*types.BatchPoolSwapMsg, 
 			// full match
 			match.BatchMsg.ExchangedOfferCoin = match.BatchMsg.ExchangedOfferCoin.Add(
 				sdk.NewCoin(match.BatchMsg.RemainingOfferCoin.Denom, match.TransactedCoinAmt))
-			fmt.Println(match)
-			fmt.Println(match.BatchMsg)
-			fmt.Println(match.BatchMsg.RemainingOfferCoin, sdk.NewCoin(match.BatchMsg.RemainingOfferCoin.Denom, match.TransactedCoinAmt))
 
 			match.BatchMsg.RemainingOfferCoin = types.CoinSafeSubAmount(match.BatchMsg.RemainingOfferCoin, match.TransactedCoinAmt)
 			//match.BatchMsg.RemainingOfferCoin.Sub(
@@ -350,9 +319,6 @@ func (k Keeper) UpdateState(X, Y sdk.Dec, XtoY, YtoX []*types.BatchPoolSwapMsg, 
 			// full match
 			match.BatchMsg.ExchangedOfferCoin = match.BatchMsg.ExchangedOfferCoin.Add(
 				sdk.NewCoin(match.BatchMsg.RemainingOfferCoin.Denom, match.TransactedCoinAmt))
-			fmt.Println(match)
-			fmt.Println(match.BatchMsg)
-			fmt.Println(match.BatchMsg.RemainingOfferCoin, sdk.NewCoin(match.BatchMsg.Msg.OfferCoin.Denom, match.TransactedCoinAmt))
 			match.BatchMsg.RemainingOfferCoin = types.CoinSafeSubAmount(match.BatchMsg.RemainingOfferCoin, match.TransactedCoinAmt)
 			//match.BatchMsg.RemainingOfferCoin = match.BatchMsg.RemainingOfferCoin.Sub(
 			//	sdk.NewCoin(match.BatchMsg.Msg.OfferCoin.Denom, match.TransactedCoinAmt))

--- a/x/liquidity/types/swap.go
+++ b/x/liquidity/types/swap.go
@@ -196,15 +196,12 @@ func MatchOrderbook(X, Y, currentPrice sdk.Dec, orderBook OrderBook) (result Bat
 	priceDirection := GetPriceDirection(currentPrice, orderBook)
 
 	if priceDirection == Stay {
-		fmt.Println("priceDirection: stay")
 		return CalculateMatchStay(currentPrice, orderBook)
 	} else { // Increase, Decrease
 		if priceDirection == Decrease {
 			orderBook.Reverse()
-			fmt.Println("priceDirection: decrease")
-		} else {
-			fmt.Println("priceDirection: increase")
 		}
+
 		return CalculateMatch(priceDirection, X, Y, currentPrice, orderBook)
 	}
 }
@@ -225,11 +222,6 @@ func CheckValidityOrderBook(orderBook OrderBook, currentPrice sdk.Dec) bool {
 	// TODO: fix naive error rate
 	oneOverWithErr, _ := sdk.NewDecFromStr("1.10")
 	oneUnderWithErr, _ := sdk.NewDecFromStr("0.90")
-
-	fmt.Println(maxBuyOrderPrice.GT(minSellOrderPrice),
-		maxBuyOrderPrice.Quo(currentPrice).GT(oneOverWithErr),
-		minSellOrderPrice.Quo(currentPrice).LT(oneUnderWithErr), maxBuyOrderPrice, minSellOrderPrice, currentPrice,
-		maxBuyOrderPrice.Quo(currentPrice), minSellOrderPrice.Quo(currentPrice))
 
 	if maxBuyOrderPrice.GT(minSellOrderPrice) ||
 		maxBuyOrderPrice.Quo(currentPrice).GT(oneOverWithErr) ||
@@ -532,7 +524,6 @@ func CalculateMatch(direction int, X, Y, currentPrice sdk.Dec, orderBook OrderBo
 	}
 	return maxScenario
 }
-
 
 // Check swap price validity using list of match result.
 func CheckSwapPrice(matchResultXtoY, matchResultYtoX []MatchResult, swapPrice sdk.Dec) bool {


### PR DESCRIPTION
### Description

Removed all the `fmt.Println` function calls from the liquidity_pool and swap files, see below for logs removed  :arrow_down: 

![Selection_039](https://user-images.githubusercontent.com/6751821/101539074-db794400-3995-11eb-8515-bb3bf8b7769a.png)

### How to test

#### Compiling
- `make install`

#### Initializing chain

- `liquidityd init testing --chain-id testing`
- `liquidityd keys add validator --keyring-backend test`
- `liquidityd add-genesis-account $(liquidityd keys show validator --keyring-backend test -a) 1000000000stake,1000000000token`
- `liquidityd gentx validator --chain-id testing --keyring-backend test`
- `liquidityd collect-gentxs`

- `liquidityd start > liquidityd.log 2>&1 &`

- `sleep 10`

#### Creating pool

- `liquidityd tx liquidity create-pool 1 100000000stake,100000000token --from validator --keyring-backend test --chain-id testing -y`

#### Swap

- `liquidityd tx liquidity swap 1 1 1 1000stake token 1.15 --from validator --chain-id testing --keyring-backend test -y`

- There should be less output from commands :+1: 