### PR TITLE
Fix empty, incorrect pool cases

### DIFF
--- a/x/liquidity/keeper/msg_server.go
+++ b/x/liquidity/keeper/msg_server.go
@@ -91,6 +91,8 @@ func (k msgServer) WithdrawFromLiquidityPool(goCtx context.Context, msg *types.M
 // Message server, handler for MsgSwap
 func (k msgServer) Swap(goCtx context.Context, msg *types.MsgSwap) (*types.MsgSwapResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	k.Keeper.SwapLiquidityPoolToBatch(ctx, msg, 0)
+	if _, err := k.Keeper.SwapLiquidityPoolToBatch(ctx, msg, 0); err != nil {
+		return &types.MsgSwapResponse{}, err
+	}
 	return &types.MsgSwapResponse{}, nil
 }

--- a/x/liquidity/types/errors.go
+++ b/x/liquidity/types/errors.go
@@ -40,4 +40,5 @@ var (
 	ErrBadBatchMsgIndex             = sdkerrors.Register(ModuleName, 32, "bad msg index of the batch")
 	ErrSwapTypeNotExists            = sdkerrors.Register(ModuleName, 33, "swap type not exists")
 	ErrLessThanMinOfferAmount       = sdkerrors.Register(ModuleName, 34, "offer amount should over 1000 micro")
+	ErrNotMatchedReserveCoin       = sdkerrors.Register(ModuleName, 35, "does not match the reserve coin of the pool")
 )

--- a/x/liquidity/types/swap_test.go
+++ b/x/liquidity/types/swap_test.go
@@ -215,7 +215,7 @@ func TestMaxOrderRatio(t *testing.T) {
 	app.SaveAccount(simapp, ctx, addrs[2], sdk.NewCoins(offerCoinY))
 
 	msgBuy := types.NewMsgSwap(addrs[1], poolId, DefaultPoolTypeIndex, DefaultSwapType, offerCoin, DenomY, priceBuy)
-	msgSell := types.NewMsgSwap(addrs[2], poolId, DefaultPoolTypeIndex, DefaultSwapType, offerCoinY, DenomY, priceSell)
+	msgSell := types.NewMsgSwap(addrs[2], poolId, DefaultPoolTypeIndex, DefaultSwapType, offerCoinY, DenomX, priceSell)
 
 	_, err := simapp.LiquidityKeeper.SwapLiquidityPoolToBatch(ctx, msgBuy, 0)
 	require.NoError(t, err)
@@ -231,7 +231,7 @@ func TestMaxOrderRatio(t *testing.T) {
 	app.SaveAccount(simapp, ctx, addrs[2], sdk.NewCoins(offerCoinY))
 
 	msgBuy = types.NewMsgSwap(addrs[1], poolId, DefaultPoolTypeIndex, DefaultSwapType, offerCoin, DenomY, priceBuy)
-	msgSell = types.NewMsgSwap(addrs[2], poolId, DefaultPoolTypeIndex, DefaultSwapType, offerCoinY, DenomY, priceSell)
+	msgSell = types.NewMsgSwap(addrs[2], poolId, DefaultPoolTypeIndex, DefaultSwapType, offerCoinY, DenomX, priceSell)
 
 	_, err = simapp.LiquidityKeeper.SwapLiquidityPoolToBatch(ctx, msgBuy, 0)
 	require.Equal(t, types.ErrExceededMaxOrderable, err)
@@ -247,7 +247,7 @@ func TestMaxOrderRatio(t *testing.T) {
 	app.SaveAccount(simapp, ctx, addrs[2], sdk.NewCoins(offerCoinY))
 
 	msgBuy = types.NewMsgSwap(addrs[1], poolId, DefaultPoolTypeIndex, DefaultSwapType, offerCoin, DenomY, priceBuy)
-	msgSell = types.NewMsgSwap(addrs[2], poolId, DefaultPoolTypeIndex, DefaultSwapType, offerCoinY, DenomY, priceSell)
+	msgSell = types.NewMsgSwap(addrs[2], poolId, DefaultPoolTypeIndex, DefaultSwapType, offerCoinY, DenomX, priceSell)
 
 	_, err = simapp.LiquidityKeeper.SwapLiquidityPoolToBatch(ctx, msgBuy, 0)
 	require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestMaxOrderRatio(t *testing.T) {
 	app.SaveAccount(simapp, ctx, addrs[2], sdk.NewCoins(offerCoinY))
 
 	msgBuy = types.NewMsgSwap(addrs[1], poolId, DefaultPoolTypeIndex, DefaultSwapType, offerCoin, DenomY, priceBuy)
-	msgSell = types.NewMsgSwap(addrs[2], poolId, DefaultPoolTypeIndex, DefaultSwapType, offerCoinY, DenomY, priceSell)
+	msgSell = types.NewMsgSwap(addrs[2], poolId, DefaultPoolTypeIndex, DefaultSwapType, offerCoinY, DenomX, priceSell)
 
 	_, err = simapp.LiquidityKeeper.SwapLiquidityPoolToBatch(ctx, msgBuy, 0)
 	require.Equal(t, types.ErrExceededMaxOrderable, err)


### PR DESCRIPTION
Fix Depositing to an empty pool results in consensus failure https://github.com/tendermint/liquidity/issues/89
and Trying to buy tokens from an incorrect pool results in chain halting https://github.com/tendermint/liquidity/issues/90 cases