### PR TITLE
Add Distribution keeper for module account invariants

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -328,7 +328,7 @@ func NewLiquidityApp(
 
 	app.LiquidityKeeper = liquiditykeeper.NewKeeper(
 		appCodec, keys[liquiditytypes.StoreKey], app.GetSubspace(liquiditytypes.ModuleName),
-		app.BankKeeper, app.AccountKeeper,
+		app.BankKeeper, app.AccountKeeper, app.DistrKeeper,
 	)
 
 	var skipGenesisInvariants = cast.ToBool(appOpts.Get(crisis.FlagSkipGenesisInvariants))
@@ -355,7 +355,7 @@ func NewLiquidityApp(
 		ibc.NewAppModule(app.IBCKeeper),
 		params.NewAppModule(app.ParamsKeeper),
 		transferModule,
-		liquidity.NewAppModule(appCodec, app.LiquidityKeeper, app.AccountKeeper, app.BankKeeper),
+		liquidity.NewAppModule(appCodec, app.LiquidityKeeper, app.AccountKeeper, app.BankKeeper, app.DistrKeeper),
 	)
 
 	// During begin block slashing happens after distr.BeginBlocker so that
@@ -406,7 +406,7 @@ func NewLiquidityApp(
 		slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
 		params.NewAppModule(app.ParamsKeeper),
 		evidence.NewAppModule(app.EvidenceKeeper),
-		liquidity.NewAppModule(appCodec, app.LiquidityKeeper, app.AccountKeeper, app.BankKeeper),
+		liquidity.NewAppModule(appCodec, app.LiquidityKeeper, app.AccountKeeper, app.BankKeeper, app.DistrKeeper),
 		ibc.NewAppModule(app.IBCKeeper),
 		transferModule,
 	)

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -402,6 +402,7 @@ func CreateTestInput() (*LiquidityApp, sdk.Context) {
 		app.GetSubspace(types.ModuleName),
 		app.BankKeeper,
 		app.AccountKeeper,
+		app.DistrKeeper,
 	)
 
 	return app, ctx

--- a/x/liquidity/keeper/keeper.go
+++ b/x/liquidity/keeper/keeper.go
@@ -16,6 +16,7 @@ type Keeper struct {
 	storeKey      sdk.StoreKey
 	bankKeeper    types.BankKeeper
 	accountKeeper types.AccountKeeper
+	distrKeeper   types.DistributionKeeper
 	paramSpace    paramstypes.Subspace
 }
 
@@ -23,7 +24,7 @@ type Keeper struct {
 // - creating new ModuleAccounts for each pool ReserveAccount
 // - sending to and from ModuleAccounts
 // - minting, burning PoolCoins
-func NewKeeper(cdc codec.Marshaler, key sdk.StoreKey, paramSpace paramstypes.Subspace, bankKeeper types.BankKeeper, accountKeeper types.AccountKeeper) Keeper {
+func NewKeeper(cdc codec.Marshaler, key sdk.StoreKey, paramSpace paramstypes.Subspace, bankKeeper types.BankKeeper, accountKeeper types.AccountKeeper, distrKeeper types.DistributionKeeper) Keeper {
 	// ensure liquidity module account is set
 	if addr := accountKeeper.GetModuleAddress(types.ModuleName); addr == nil {
 		panic(fmt.Sprintf("%s module account has not been set", types.ModuleName))
@@ -38,6 +39,7 @@ func NewKeeper(cdc codec.Marshaler, key sdk.StoreKey, paramSpace paramstypes.Sub
 		storeKey:      key,
 		bankKeeper:    bankKeeper,
 		accountKeeper: accountKeeper,
+		distrKeeper:   distrKeeper,
 		cdc:           cdc,
 		paramSpace:    paramSpace,
 	}

--- a/x/liquidity/keeper/liquidity_pool.go
+++ b/x/liquidity/keeper/liquidity_pool.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/tendermint/liquidity/x/liquidity/types"
 	"strconv"
 )
@@ -153,9 +152,6 @@ func (k Keeper) CreateLiquidityPool(ctx sdk.Context, msg *types.MsgCreateLiquidi
 	}
 
 	batchEscrowAcc := k.accountKeeper.GetModuleAddress(types.ModuleName)
-	// pool creation fees are collected in community pool
-	// TODO: verify distr community pool is consistency safe for collected fee
-	poolCreationFeePoolAcc := k.accountKeeper.GetModuleAddress(distrtypes.ModuleName)
 	mintPoolCoin := sdk.NewCoins(sdk.NewCoin(pool.PoolCoinDenom, params.InitPoolCoinMintAmount))
 	if err := k.bankKeeper.MintCoins(ctx, types.ModuleName, mintPoolCoin); err != nil {
 		return types.LiquidityPool{}, err
@@ -163,9 +159,6 @@ func (k Keeper) CreateLiquidityPool(ctx sdk.Context, msg *types.MsgCreateLiquidi
 
 	var inputs []banktypes.Input
 	var outputs []banktypes.Output
-
-	inputs = append(inputs, banktypes.NewInput(poolCreator, params.LiquidityPoolCreationFee))
-	outputs = append(outputs, banktypes.NewOutput(poolCreationFeePoolAcc, params.LiquidityPoolCreationFee))
 
 	inputs = append(inputs, banktypes.NewInput(poolCreator, msg.DepositCoins))
 	outputs = append(outputs, banktypes.NewOutput(reserveAcc, msg.DepositCoins))
@@ -175,6 +168,11 @@ func (k Keeper) CreateLiquidityPool(ctx sdk.Context, msg *types.MsgCreateLiquidi
 
 	// execute multi-send
 	if err := k.bankKeeper.InputOutputCoins(ctx, inputs, outputs); err != nil {
+		return types.LiquidityPool{}, err
+	}
+
+	// pool creation fees are collected in community pool
+	if err := k.distrKeeper.FundCommunityPool(ctx, params.LiquidityPoolCreationFee, poolCreator); err != nil {
 		return types.LiquidityPool{}, err
 	}
 

--- a/x/liquidity/keeper/swap_test.go
+++ b/x/liquidity/keeper/swap_test.go
@@ -332,7 +332,6 @@ func TestBadSwapExecution(t *testing.T) {
 	params := simapp.LiquidityKeeper.GetParams(ctx)
 	denomX, denomY := types.AlphabeticalDenomPair("denomX", "denomY")
 
-
 	// add pool creator account
 	X, Y := app.GetRandPoolAmt(r, params.MinInitDepositToPool)
 	deposit := sdk.NewCoins(sdk.NewCoin(denomX, X), sdk.NewCoin(denomY, Y))

--- a/x/liquidity/module.go
+++ b/x/liquidity/module.go
@@ -99,6 +99,7 @@ type AppModule struct {
 	keeper        keeper.Keeper
 	accountKeeper types.AccountKeeper
 	bankKeeper    types.BankKeeper
+	distrKeeper   types.DistributionKeeper
 }
 
 // RegisterLegacyAminoCodec registers the gov module's types for the given codec.
@@ -107,12 +108,13 @@ func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(cdc codec.Marshaler, keeper keeper.Keeper, ak types.AccountKeeper, bk types.BankKeeper) AppModule {
+func NewAppModule(cdc codec.Marshaler, keeper keeper.Keeper, ak types.AccountKeeper, bk types.BankKeeper, dk types.DistributionKeeper) AppModule {
 	return AppModule{
 		AppModuleBasic: AppModuleBasic{cdc: cdc},
 		keeper:         keeper,
 		accountKeeper:  ak,
 		bankKeeper:     bk,
+		distrKeeper:    dk,
 	}
 }
 

--- a/x/liquidity/types/expected_keepers.go
+++ b/x/liquidity/types/expected_keepers.go
@@ -26,3 +26,8 @@ type AccountKeeper interface {
 	GetAccount(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
 	GetModuleAddress(name string) sdk.AccAddress
 }
+
+// DistributionKeeper defines the expected distribution keeper
+type DistributionKeeper interface {
+	FundCommunityPool(ctx sdk.Context, amount sdk.Coins, sender sdk.AccAddress) error
+}

--- a/x/liquidity/types/msgs_test.go
+++ b/x/liquidity/types/msgs_test.go
@@ -249,14 +249,14 @@ func TestMsgValidateBasic(t *testing.T) {
 			{
 				types.MsgDepositToLiquidityPool{
 					DepositorAddress: validAddr,
-					DepositCoins: sdk.NewCoins(sdk.NewCoin(DenomX, sdk.NewInt(int64(types.MinReserveCoinNum)-1))),
+					DepositCoins:     sdk.NewCoins(sdk.NewCoin(DenomX, sdk.NewInt(int64(types.MinReserveCoinNum)-1))),
 				},
 				types.ErrNumOfReserveCoin.Error(),
 			},
 			{
 				types.MsgDepositToLiquidityPool{
 					DepositorAddress: validAddr,
-					DepositCoins: sdk.NewCoins(sdk.NewCoin(DenomX, sdk.NewInt(int64(types.MaxReserveCoinNum)+1))),
+					DepositCoins:     sdk.NewCoins(sdk.NewCoin(DenomX, sdk.NewInt(int64(types.MaxReserveCoinNum)+1))),
 				},
 				types.ErrNumOfReserveCoin.Error(),
 			},
@@ -267,11 +267,11 @@ func TestMsgValidateBasic(t *testing.T) {
 	})
 	t.Run("MsgWithdrawFromLiquidityPool", func(t *testing.T) {
 		for _, tc := range []struct {
-			msg types.MsgWithdrawFromLiquidityPool
+			msg    types.MsgWithdrawFromLiquidityPool
 			errMsg string
-		} {
+		}{
 			{
-				types.MsgWithdrawFromLiquidityPool{ },
+				types.MsgWithdrawFromLiquidityPool{},
 				types.ErrEmptyWithdrawerAddr.Error(),
 			},
 			{

--- a/x/liquidity/types/params.go
+++ b/x/liquidity/types/params.go
@@ -52,7 +52,7 @@ var (
 	halfRatio, _ = sdk.NewDecFromStr("0.5")
 	HalfRatio    = halfRatio
 
-	DecimalErrThreshold3 = sdk.NewDecFromIntWithPrec(sdk.OneInt(), 3)
+	DecimalErrThreshold3  = sdk.NewDecFromIntWithPrec(sdk.OneInt(), 3)
 	DecimalErrThreshold10 = sdk.NewDecFromIntWithPrec(sdk.OneInt(), 10)
 
 	DefaultLiquidityPoolType = LiquidityPoolType{

--- a/x/liquidity/types/swap_test.go
+++ b/x/liquidity/types/swap_test.go
@@ -624,42 +624,42 @@ func TestGetOrderMapEdgeCase(t *testing.T) {
 func TestCheckValidityOrderBook(t *testing.T) {
 	currentPrice := sdk.MustNewDecFromStr("1.0")
 	for _, testCase := range []struct {
-		buyPrice string
+		buyPrice  string
 		sellPrice string
-		valid bool
+		valid     bool
 	}{
 		{
-			buyPrice: "0.99",
+			buyPrice:  "0.99",
 			sellPrice: "1.01",
-			valid: true,
+			valid:     true,
 		},
 		{
 			// maxBuyOrderPrice > minSellOrderPrice
-			buyPrice: "1.01",
+			buyPrice:  "1.01",
 			sellPrice: "0.99",
-			valid: false,
+			valid:     false,
 		},
 		{
-			buyPrice: "1.1",
+			buyPrice:  "1.1",
 			sellPrice: "1.2",
-			valid: true,
+			valid:     true,
 		},
 		{
 			// maxBuyOrderPrice/currentPrice > 1.10
-			buyPrice: "1.11",
+			buyPrice:  "1.11",
 			sellPrice: "1.2",
-			valid: false,
+			valid:     false,
 		},
 		{
-			buyPrice: "0.8",
+			buyPrice:  "0.8",
 			sellPrice: "0.9",
-			valid: true,
+			valid:     true,
 		},
 		{
 			// minSellOrderPrice/currentPrice < 0.90
-			buyPrice: "0.8",
+			buyPrice:  "0.8",
 			sellPrice: "0.89",
-			valid: false,
+			valid:     false,
 		},
 	} {
 		buyPrice := sdk.MustNewDecFromStr(testCase.buyPrice)


### PR DESCRIPTION
Add Distribution keeper for module account invariants
fix from direct sending to calling distrKeeper.FundCommunityPool when paying pool creation fees to the community pool