### PR TITLE
Randomized UnitBatchSize in genesis for the simulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ benchmark:
 test-sim-nondeterminism:
 	@echo "Running non-determinism test..."
 	@go test -mod=readonly $(SIMAPP) -run TestAppStateDeterminism -Enabled=true \
-		-NumBlocks=50 -BlockSize=200 -Commit=true -Period=0 -v -timeout 24h
+		-NumBlocks=100 -BlockSize=1000 -Commit=true -Period=0 -v -timeout 24h
 
 test-sim-import-export: runsim
 	@echo "Running application import/export simulation. This may take several minutes..."

--- a/x/liquidity/simulation/decoder_test.go
+++ b/x/liquidity/simulation/decoder_test.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cosmos/cosmos-sdk/simapp"
 	"github.com/cosmos/cosmos-sdk/types/kv"
-	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/liquidity/x/liquidity/simulation"
 	"github.com/tendermint/liquidity/x/liquidity/types"

--- a/x/liquidity/simulation/genesis.go
+++ b/x/liquidity/simulation/genesis.go
@@ -87,8 +87,7 @@ func GenMaxOrderAmountRatio(r *rand.Rand) sdk.Dec {
 
 // GenUnitBatchSize randomized UnitBatchSize ranging from 1 to 20
 func GenUnitBatchSize(r *rand.Rand) uint32 {
-	return uint32(1) // due to simulation error, set 1 temporarily
-	// return uint32(simulation.RandIntBetween(r, int(types.DefaultUnitBatchSize), 20))
+	return uint32(simulation.RandIntBetween(r, int(types.DefaultUnitBatchSize), 20))
 }
 
 // RandomizedGenState generates a random GenesisState for liquidity

--- a/x/liquidity/simulation/genesis_test.go
+++ b/x/liquidity/simulation/genesis_test.go
@@ -5,12 +5,13 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
-	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/liquidity/x/liquidity/simulation"
 	"github.com/tendermint/liquidity/x/liquidity/types"

--- a/x/liquidity/simulation/genesis_test.go
+++ b/x/liquidity/simulation/genesis_test.go
@@ -52,7 +52,7 @@ func TestRandomizedGenState(t *testing.T) {
 	require.Equal(t, dec4, liquidityGenesis.Params.SwapFeeRate)
 	require.Equal(t, dec5, liquidityGenesis.Params.WithdrawFeeRate)
 	require.Equal(t, dec6, liquidityGenesis.Params.MaxOrderAmountRatio)
-	require.Equal(t, uint32(1), liquidityGenesis.Params.UnitBatchSize)
+	require.Equal(t, uint32(6), liquidityGenesis.Params.UnitBatchSize)
 }
 
 // TestRandomizedGenState tests abnormal scenarios of applying RandomizedGenState.

--- a/x/liquidity/simulation/params.go
+++ b/x/liquidity/simulation/params.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/cosmos/cosmos-sdk/x/simulation"
-
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/cosmos/cosmos-sdk/x/simulation"
 
 	"github.com/tendermint/liquidity/x/liquidity/types"
 )

--- a/x/liquidity/simulation/params_test.go
+++ b/x/liquidity/simulation/params_test.go
@@ -25,7 +25,7 @@ func TestParamChanges(t *testing.T) {
 		{"liquidity/SwapFeeRate", "SwapFeeRate", "\"0.934590000000000000\"", "liquidity"},
 		{"liquidity/WithdrawFeeRate", "WithdrawFeeRate", "\"0.112010000000000000\"", "liquidity"},
 		{"liquidity/MaxOrderAmountRatio", "MaxOrderAmountRatio", "\"0.560680000000000000\"", "liquidity"},
-		{"liquidity/UnitBatchSize", "UnitBatchSize", "1", "liquidity"},
+		{"liquidity/UnitBatchSize", "UnitBatchSize", "19", "liquidity"},
 	}
 
 	paramChanges := simulation.ParamChanges(r)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR randomizes param `UnitBatchSize` in genesis for the simulation 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #130

- [x] update `UnitBatchSize` in genesis
- [x] update tests 
- [x] run make test-unit to make sure every test passes
- [ ] `out of gas in location` error still persists when running with more than 1000 BlockSize 

The error can also be reproduced in Cosmos SDK v0.42.0 when increasing `BlockSize` to higher numbers to more than 1000

```
simulate.go:297: error on block  13/1000, operation (2339/3691) from x/staking:
out of gas in location: WritePerByte; gasWanted: 1000000, gasUsed: 1013866
Comment: unable to deliver tx
```
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
