### PR TITLE
Fix refund issue in swap logic when MatchType is 0

### DIFF
--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -246,7 +246,7 @@ func GetRandomSizeOrders(denomX, denomY string, X, Y sdk.Int, r *rand.Rand, size
 func GetRandomOrders(denomX, denomY string, X, Y sdk.Int, r *rand.Rand, sizeXtoY, sizeYtoX int) (XtoY, YtoX []*types.MsgSwapWithinBatch) {
 	currentPrice := X.ToDec().Quo(Y.ToDec())
 
-	for i := 0; i < sizeXtoY; i++ {
+	for len(XtoY) < sizeXtoY {
 		orderPrice := currentPrice.Mul(sdk.NewDecFromIntWithPrec(GetRandRange(r, 991, 1009), 3))
 		//offerAmt := X.ToDec().Mul(sdk.NewDecFromIntWithPrec(GetRandRange(r, 1, 100), 4))
 		orderAmt := sdk.ZeroDec()
@@ -255,7 +255,10 @@ func GetRandomOrders(denomX, denomY string, X, Y sdk.Int, r *rand.Rand, sizeXtoY
 		} else {
 			orderAmt = sdk.NewDecFromIntWithPrec(GetRandRange(r, 1000, 10000), 0)
 		}
-		orderCoin := sdk.NewCoin(denomX, orderAmt.RoundInt())
+		if orderAmt.Quo(orderPrice).TruncateInt().IsZero() {
+			continue
+		}
+		orderCoin := sdk.NewCoin(denomX, orderAmt.Ceil().TruncateInt())
 
 		XtoY = append(XtoY, &types.MsgSwapWithinBatch{
 			OfferCoin:       orderCoin,
@@ -264,7 +267,7 @@ func GetRandomOrders(denomX, denomY string, X, Y sdk.Int, r *rand.Rand, sizeXtoY
 		})
 	}
 
-	for i := 0; i < sizeYtoX; i++ {
+	for len(YtoX) < sizeYtoX {
 		orderPrice := currentPrice.Mul(sdk.NewDecFromIntWithPrec(GetRandRange(r, 991, 1009), 3))
 		//offerAmt := Y.ToDec().Mul(sdk.NewDecFromIntWithPrec(GetRandRange(r, 1, 100), 4))
 		orderAmt := sdk.ZeroDec()
@@ -273,7 +276,10 @@ func GetRandomOrders(denomX, denomY string, X, Y sdk.Int, r *rand.Rand, sizeXtoY
 		} else {
 			orderAmt = sdk.NewDecFromIntWithPrec(GetRandRange(r, 1000, 10000), 0)
 		}
-		orderCoin := sdk.NewCoin(denomY, orderAmt.RoundInt())
+		if orderAmt.Mul(orderPrice).TruncateInt().IsZero() {
+			continue
+		}
+		orderCoin := sdk.NewCoin(denomY, orderAmt.Ceil().TruncateInt())
 
 		YtoX = append(YtoX, &types.MsgSwapWithinBatch{
 			OfferCoin:       orderCoin,

--- a/x/liquidity/keeper/liquidity_pool.go
+++ b/x/liquidity/keeper/liquidity_pool.go
@@ -763,6 +763,8 @@ func (k Keeper) RefundSwaps(ctx sdk.Context, pool types.Pool, swapMsgStates []*t
 				inputs = append(inputs, input)
 				outputs = append(outputs, output)
 			}
+			sms.Succeeded = false
+			sms.ToBeDeleted = true
 		}
 	}
 	// remove zero coins

--- a/x/liquidity/types/swap_test.go
+++ b/x/liquidity/types/swap_test.go
@@ -86,12 +86,13 @@ func TestSwapScenario(t *testing.T) {
 
 	// The price and coins of swap messages in orderbook are calculated
 	// to derive match result with the price direction.
-	result := orderBook.Match(X.ToDec(), Y.ToDec())
+	result, found := orderBook.Match(X.ToDec(), Y.ToDec())
+	require.True(t, found)
 	require.NotEqual(t, types.NoMatch, result.MatchType)
 
-	matchResultXtoY, _, poolXDeltaXtoY, poolYDeltaXtoY := types.FindOrderMatch(types.DirectionXtoY, XtoY, result.EX,
+	matchResultXtoY, poolXDeltaXtoY, poolYDeltaXtoY := types.FindOrderMatch(types.DirectionXtoY, XtoY, result.EX,
 		result.SwapPrice, ctx.BlockHeight())
-	matchResultYtoX, _, poolXDeltaYtoX, poolYDeltaYtoX := types.FindOrderMatch(types.DirectionYtoX, YtoX, result.EY,
+	matchResultYtoX, poolXDeltaYtoX, poolYDeltaYtoX := types.FindOrderMatch(types.DirectionYtoX, YtoX, result.EY,
 		result.SwapPrice, ctx.BlockHeight())
 
 	XtoY, YtoX, XDec, YDec, poolXDelta2, poolYDelta2, fractionalCntX, fractionalCntY, decimalErrorX, decimalErrorY :=
@@ -439,8 +440,10 @@ func TestComputePriceDirection(t *testing.T) {
 
 	poolPrice := X.Quo(Y)
 	direction := orderBook.PriceDirection(poolPrice)
-	result := orderBook.Match(X, Y)
-	require.Equal(t, orderBook.CalculateMatch(direction, X, Y), result)
+	result, found := orderBook.Match(X, Y)
+	result2, found2 := orderBook.CalculateMatch(direction, X, Y)
+	require.Equal(t, found2, found)
+	require.Equal(t, result2, result)
 
 	// decrease case
 	orderMap = make(types.OrderMap)
@@ -470,8 +473,10 @@ func TestComputePriceDirection(t *testing.T) {
 
 	poolPrice = X.Quo(Y)
 	direction = orderBook.PriceDirection(poolPrice)
-	result = orderBook.Match(X, Y)
-	require.Equal(t, orderBook.CalculateMatch(direction, X, Y), result)
+	result, found = orderBook.Match(X, Y)
+	result2, found2 = orderBook.CalculateMatch(direction, X, Y)
+	require.Equal(t, found2, found)
+	require.Equal(t, result2, result)
 
 	// stay case
 	orderMap = make(types.OrderMap)
@@ -488,8 +493,9 @@ func TestComputePriceDirection(t *testing.T) {
 	Y = orderMap[a.String()].SellOfferAmt.ToDec()
 	poolPrice = X.Quo(Y)
 
-	result = orderBook.Match(X, Y)
-	require.Equal(t, orderBook.CalculateMatchStay(poolPrice), result)
+	result, _ = orderBook.Match(X, Y)
+	result2 = orderBook.CalculateMatchStay(poolPrice)
+	require.Equal(t, result2, result)
 }
 
 func TestCalculateMatchStay(t *testing.T) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

There is a bug in a swap logic and is fixed - when MatchType is 0, escrowed coin are not refunded to the swap requestor.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
