### PR TITLE
Add testcase for manipulation of reserve account balance

### DIFF
--- a/x/liquidity/keeper/liquidity_pool.go
+++ b/x/liquidity/keeper/liquidity_pool.go
@@ -511,8 +511,6 @@ func (k Keeper) GetPoolRecord(ctx sdk.Context, pool types.Pool) (types.PoolRecor
 // SetPoolRecord stores liquidity pool states
 func (k Keeper) SetPoolRecord(ctx sdk.Context, record types.PoolRecord) types.PoolRecord {
 	k.SetPoolAtomic(ctx, record.Pool)
-	//k.SetPool(ctx, record.Pool)
-	//k.SetPoolByReserveAccIndex(ctx, record.Pool)
 	k.GetNextPoolBatchIndexWithUpdate(ctx, record.Pool.Id)
 	record.PoolBatch.BeginHeight = ctx.BlockHeight()
 	k.SetPoolBatch(ctx, record.PoolBatch)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Add a test code to verify the pool operation even if the reserved coin balance is manipulated by sending to the reserve account

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
