### PR TITLE
swagger.yaml edits for liquidity module

### DIFF
--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -7,7 +7,7 @@ paths:
   /tendermint/liquidity/v1beta1/params:
     get:
       summary: Get all parameters of the liquidity module.
-      description: It returns all parameters of the liquidity module.
+      description: Returns all parameters of the liquidity module.
       operationId: LiquidityQueries
       responses:
         '200':
@@ -16,7 +16,7 @@ paths:
             type: object
             properties:
               params:
-                description: params holds all the parameters of this module.
+                description: Params holds all the parameters of this module.
                 type: object
                 properties:
                   pool_types:
@@ -32,7 +32,7 @@ paths:
                             The id of the pool_type to use as pool_type_id for
                             pool creation.
 
-                            Only pool-type-id 1 is supported
+                            Only pool-type-id 1 is supported.
 
                             {"id":1,"name":"ConstantProductLiquidityPool","min_reserve_coin_num":2,"max_reserve_coin_num":2,"description":""}
                         name:
@@ -44,15 +44,15 @@ paths:
                           format: uint32
                           example: '2'
                           title: >-
-                            min number of reserveCoins for LiquidityPoolType
-                            only 2 is allowed on this spec
+                            minimum number of reserveCoins for LiquidityPoolType
+                            only 2 coins are allowed on this spec
                         max_reserve_coin_num:
                           type: integer
                           format: uint32
                           example: '2'
                           title: >-
-                            max number of reserveCoins for LiquidityPoolType
-                            only 2 is allowed on this spec
+                            maximum number of reserveCoins for LiquidityPoolType
+                            only 2 coins are allowed on this spec
                         description:
                           type: string
                           title: description of the pool type
@@ -66,12 +66,12 @@ paths:
                     example: '1000000'
                     title: >-
                       Minimum number of coins to be deposited to the liquidity
-                      pool upon pool creation
+                      pool on pool creation
                   init_pool_coin_mint_amount:
                     type: string
                     format: sdk.Int
                     example: '1000000'
-                    title: Initial mint amount of pool coin upon pool creation
+                    title: Initial mint amount of pool coin on pool creation
                   max_reserve_coin_amount:
                     type: string
                     format: sdk.Int
@@ -79,7 +79,7 @@ paths:
                     title: >-
                       Limit the size of each liquidity pool in the beginning
                       phase of Liquidity Module adoption to minimize risk, 0
-                      means no limit
+                      means no limit to the maximum reserve coin amount
                   pool_creation_fee:
                     type: array
                     format: sdk.Coins
@@ -97,11 +97,11 @@ paths:
                         Coin defines a token with a denomination and an amount.
 
 
-                        NOTE: The amount field is an Int which implements the
+                        NOTE: The amount field is an Int that implements the
                         custom method
 
                         signatures required by gogoproto.
-                    description: Fee to create a Liquidity Pool.
+                    description: Fee to create a Liquidity Pool
                   swap_fee_rate:
                     type: string
                     format: sdk.Dec
@@ -125,10 +125,9 @@ paths:
                     type: integer
                     format: uint32
                     example: '1'
-                    title: The smallest unit batch height for every liquidity pool
+                    title: The smallest unit batch height for each liquidity pool
             description: >-
-              the response type for the QueryParamsResponse RPC method. This
-              includes current parameter of the liquidity module.
+              The response type for the QueryParamsResponse RPC method. This response includes current parameter of the liquidity module.
         default:
           description: An unexpected error response.
           schema:
@@ -160,7 +159,7 @@ paths:
   /tendermint/liquidity/v1beta1/pools:
     get:
       summary: Get existing liquidity pools.
-      description: It returns list of all liquidity pools with pagination result.
+      description: Returns a list of all liquidity pools with pagination result.
       operationId: LiquidityPools
       responses:
         '200':
@@ -200,11 +199,11 @@ paths:
                       type: string
                       example: >-
                         poolD35A0CC16EE598F90B044CE296A405BA9C381E38837599D96F2F70C2F02A23A4
-                      title: denom of pool coin of the pool
+                      title: denom of pool coins in the pool
                   title: The liquidity pool information
               pagination:
                 description: >-
-                  pagination defines the pagination in the response. not working
+                  Pagination defines the pagination in the response. Not working
                   on this version.
                 type: object
                 properties:
@@ -223,9 +222,9 @@ paths:
 
                       was set, its value is undefined otherwise
             description: >-
-              the response type for the QueryLiquidityPoolsResponse RPC method.
-              This includes list of all liquidity pools currently existed and
-              paging results containing next_key and total count.
+              The response type for the QueryLiquidityPoolsResponse RPC method.
+              This response includes a list of all existing liquidity pools and
+              paging results that contain the next_key and total count.
         '500':
           description: Internal Server Error
           schema: {}
@@ -261,44 +260,38 @@ paths:
       parameters:
         - name: pagination.key
           description: |-
-            key is a value returned in PageResponse.next_key to begin
-            querying the next page most efficiently. Only one of offset or key
-            should be set.
+            Key is a value that is returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Set either offset or key.
           in: query
           required: false
           type: string
           format: byte
         - name: pagination.offset
           description: >-
-            offset is a numeric offset that can be used when key is unavailable.
-
-            It is less efficient than using key. Only one of offset or key
-            should
-
-            be set.
+            Set either offset or key. When key is unavailable, use offset. Offset is less efficient than using key. 
           in: query
           required: false
           type: string
           format: uint64
         - name: pagination.limit
           description: >-
-            limit is the total number of results to be returned in the result
+            Limit is the total number of results to be returned in the result
             page.
 
-            If left empty it will default to a value to be set by each app.
+            If left empty, the default is a value that is set by each app.
           in: query
           required: false
           type: string
           format: uint64
         - name: pagination.count_total
           description: >-
-            count_total is set to true  to indicate that the result set should
+            count_total is set to true to indicate that the result set should
             include
 
             a count of the total number of items available for pagination in
             UIs.
 
-            count_total is only respected when offset is used. It is ignored
+            count_total is respected only when offset is used and is ignored
             when key
 
             is set.
@@ -313,7 +306,7 @@ paths:
   '/tendermint/liquidity/v1beta1/pools/{pool_id}':
     get:
       summary: Get specific liquidity pool.
-      description: It returns the liquidity pool corresponding to the pool_id.
+      description: Returns the  liquidity pool that corresponds to the pool_id.
       operationId: LiquidityPool
       responses:
         '200':
@@ -354,8 +347,8 @@ paths:
                     title: denom of pool coin of the pool
                 title: The liquidity pool information
             description: >-
-              the response type for the QueryLiquidityPoolResponse RPC method.
-              It returns the liquidity pool corresponding to the requested
+              The response type for the QueryLiquidityPoolResponse RPC method.
+              Returns the liquidity pool that corresponds to the requested
               pool_id.
         '400':
           description: Bad Request
@@ -413,7 +406,7 @@ paths:
   '/tendermint/liquidity/v1beta1/pools/{pool_id}/batch':
     get:
       summary: Get the pool's current batch.
-      description: It returns the current batch of the pool corresponding to the pool_id.
+      description: Returns the current batch of the pool that corresponds to the pool_id.
       operationId: LiquidityPoolBatch
       responses:
         '200':
@@ -438,7 +431,7 @@ paths:
                     type: string
                     format: int64
                     example: '1000'
-                    title: height where this batch is begun
+                    title: block height when this batch began
                   deposit_msg_index:
                     type: string
                     format: uint64
@@ -464,7 +457,7 @@ paths:
                   param increments by 1 if the pool id exists.
             description: >-
               the response type for the QueryLiquidityPoolBatchResponse RPC
-              method. It returns the liquidity pool batch corresponding to the
+              method. Returns the liquidity pool batch that corresponds to the
               requested pool_id.
         '400':
           description: Bad Request
@@ -524,7 +517,7 @@ paths:
     get:
       summary: Get all deposit messages in the pool's current batch.
       description: >-
-        It returns list of all deposit messages in the current batch of the pool
+        Returns a list of all deposit messages in the current batch of the pool
         with pagination result.
       operationId: PoolBatchDepositMsgs
       responses:
@@ -542,7 +535,7 @@ paths:
                       type: string
                       format: int64
                       example: '1000'
-                      title: height where this message is appended to the batch
+                      title: block height when this message is appended to the batch
                     msg_index:
                       type: string
                       format: uint64
@@ -600,7 +593,7 @@ paths:
                               amount.
 
 
-                              NOTE: The amount field is an Int which implements
+                              NOTE: The amount field is an Int that implements
                               the custom method
 
                               signatures required by gogoproto.
@@ -649,7 +642,7 @@ paths:
             description: >-
               the response type for the QueryPoolBatchDeposit RPC method. This
               includes a list of all currently existing deposit messages of the
-              batch and paging results containing next_key and total count.
+              batch and paging results that contains next_key and total count.
         '400':
           description: Bad Request
           schema: {}
@@ -754,7 +747,7 @@ paths:
     get:
       summary: Get specific deposit message in the pool's current batch.
       description: >-
-        It returns the deposit message corresponding to the msg_index in the
+        Returns the deposit message that corresponds to the msg_index in the
         pool's current batch.
       operationId: PoolBatchDepositMsg
       responses:
@@ -770,7 +763,7 @@ paths:
                     type: string
                     format: int64
                     example: '1000'
-                    title: height where this message is appended to the batch
+                    title: block height when this message is appended to the batch
                   msg_index:
                     type: string
                     format: uint64
@@ -826,7 +819,7 @@ paths:
                             amount.
 
 
-                            NOTE: The amount field is an Int which implements
+                            NOTE: The amount field is an Int that implements
                             the custom method
 
                             signatures required by gogoproto.
@@ -849,12 +842,10 @@ paths:
                       See:
                       https://github.com/tendermint/liquidity/blob/develop/x/liquidity/spec/04_messages.md
                 title: >-
-                  DepositMsgState defines the state of the deposit message that
-                  contains the state information as it is processed in the next
-                  batch or batches
+                  DepositMsgState defines the state of the deposit message as it is processed in the next batch or batches
             title: >-
               the response type for the QueryPoolBatchDepositMsg RPC method.
-              This includes a batch swap message of the batch
+              This response includes a batch swap message of the batch
         '400':
           description: Bad Request
           schema: {}
@@ -920,7 +911,7 @@ paths:
     get:
       summary: Get all swap messages in the pool's current batch.
       description: >-
-        It returns list of all swap messages in the current batch of the pool
+        Returns a list of all swap messages in the current batch of the pool
         with pagination result.
       operationId: PoolBatchSwapMsgs
       responses:
@@ -938,7 +929,7 @@ paths:
                       type: string
                       format: int64
                       example: '1000'
-                      title: height where this message is appended to the batch
+                      title: block height when this message is appended to the batch
                     msg_index:
                       type: string
                       format: uint64
@@ -967,8 +958,7 @@ paths:
                       format: int64
                       example: '1000'
                       title: >-
-                        swap orders are cancelled when current height is equal
-                        or higher than ExpiryHeight
+                        swap orders are cancelled when current block height is equal to or higher than ExpiryHeight
                     exchanged_offer_coin:
                       type: object
                       properties:
@@ -980,7 +970,7 @@ paths:
                         Coin defines a token with a denomination and an amount.
 
 
-                        NOTE: The amount field is an Int which implements the
+                        NOTE: The amount field is an Int that implements the
                         custom method
 
                         signatures required by gogoproto.
@@ -1000,7 +990,7 @@ paths:
                         Coin defines a token with a denomination and an amount.
 
 
-                        NOTE: The amount field is an Int which implements the
+                        NOTE: The amount field is an Int that implements the
                         custom method
 
                         signatures required by gogoproto.
@@ -1020,7 +1010,7 @@ paths:
                         Coin defines a token with a denomination and an amount.
 
 
-                        NOTE: The amount field is an Int which implements the
+                        NOTE: The amount field is an Int that implements the
                         custom method
 
                         signatures required by gogoproto.
@@ -1061,7 +1051,7 @@ paths:
                             amount.
 
 
-                            NOTE: The amount field is an Int which implements
+                            NOTE: The amount field is an Int that implements
                             the custom method
 
                             signatures required by gogoproto.
@@ -1087,7 +1077,7 @@ paths:
                             amount.
 
 
-                            NOTE: The amount field is an Int which implements
+                            NOTE: The amount field is an Int that implements
                             the custom method
 
                             signatures required by gogoproto.
@@ -1165,7 +1155,7 @@ paths:
             description: >-
               the response type for the QueryPoolBatchSwapMsgs RPC method. This
               includes list of all currently existing swap messages of the batch
-              and paging results containing next_key and total count.
+              and paging results that contains next_key and total count.
         '400':
           description: Bad Request
           schema: {}
@@ -1270,7 +1260,7 @@ paths:
     get:
       summary: Get specific swap message in the pool's current batch.
       description: >-
-        It returns the swap message corresponding to the msg_index in the pool's
+        Returns the swap message that corresponds to the msg_index in the pool's
         current batch
       operationId: PoolBatchSwapMsg
       responses:
@@ -1286,7 +1276,7 @@ paths:
                     type: string
                     format: int64
                     example: '1000'
-                    title: height where this message is appended to the batch
+                    title: block height when this message is appended to the batch
                   msg_index:
                     type: string
                     format: uint64
@@ -1313,8 +1303,7 @@ paths:
                     format: int64
                     example: '1000'
                     title: >-
-                      swap orders are cancelled when current height is equal or
-                      higher than ExpiryHeight
+                      swap orders are cancelled when current block height is equal to or higher than ExpiryHeight
                   exchanged_offer_coin:
                     type: object
                     properties:
@@ -1326,7 +1315,7 @@ paths:
                       Coin defines a token with a denomination and an amount.
 
 
-                      NOTE: The amount field is an Int which implements the
+                      NOTE: The amount field is an Int that implements the
                       custom method
 
                       signatures required by gogoproto.
@@ -1346,7 +1335,7 @@ paths:
                       Coin defines a token with a denomination and an amount.
 
 
-                      NOTE: The amount field is an Int which implements the
+                      NOTE: The amount field is an Int that implements the
                       custom method
 
                       signatures required by gogoproto.
@@ -1366,7 +1355,7 @@ paths:
                       Coin defines a token with a denomination and an amount.
 
 
-                      NOTE: The amount field is an Int which implements the
+                      NOTE: The amount field is an Int that implements the
                       custom method
 
                       signatures required by gogoproto.
@@ -1407,7 +1396,7 @@ paths:
                           amount.
 
 
-                          NOTE: The amount field is an Int which implements the
+                          NOTE: The amount field is an Int that implements the
                           custom method
 
                           signatures required by gogoproto.
@@ -1433,7 +1422,7 @@ paths:
                           amount.
 
 
-                          NOTE: The amount field is an Int which implements the
+                          NOTE: The amount field is an Int that implements the
                           custom method
 
                           signatures required by gogoproto.
@@ -1556,7 +1545,7 @@ paths:
     get:
       summary: Get all withdraw messages in the pool's current batch.
       description: >-
-        It returns list of all withdraw messages in the current batch of the
+        Returns a list of all withdraw messages in the current batch of the
         pool with pagination result.
       operationId: PoolBatchWithdrawMsgs
       responses:
@@ -1574,7 +1563,7 @@ paths:
                       type: string
                       format: int64
                       example: '1000'
-                      title: height where this message is appended to the batch
+                      title: block height when this message is appended to the batch
                     msg_index:
                       type: string
                       format: uint64
@@ -1624,7 +1613,7 @@ paths:
                             amount.
 
 
-                            NOTE: The amount field is an Int which implements
+                            NOTE: The amount field is an Int that implements
                             the custom method
 
                             signatures required by gogoproto.
@@ -1675,7 +1664,7 @@ paths:
             description: >-
               the response type for the QueryPoolBatchWithdraw RPC method. This
               includes a list of all currently existing withdraw messages of the
-              batch and paging results containing next_key and total count.
+              batch and paging results that contains next_key and total count.
         '400':
           description: Bad Request
           schema: {}
@@ -1780,7 +1769,7 @@ paths:
     get:
       summary: Get specific withdraw message in the pool's current batch.
       description: >-
-        It returns the withdraw message corresponding to the msg_index in the
+        Returns the withdraw message that corresponds to the msg_index in the
         pool's current batch.
       operationId: PoolBatchWithdrawMsg
       responses:
@@ -1796,7 +1785,7 @@ paths:
                     type: string
                     format: int64
                     example: '1000'
-                    title: height where this message is appended to the batch
+                    title: block height when this message is appended to the batch
                   msg_index:
                     type: string
                     format: uint64
@@ -1844,7 +1833,7 @@ paths:
                           amount.
 
 
-                          NOTE: The amount field is an Int which implements the
+                          NOTE: The amount field is an Int that implements the
                           custom method
 
                           signatures required by gogoproto.
@@ -1874,7 +1863,7 @@ paths:
                   batch or batches
             title: >-
               the response type for the QueryPoolBatchWithdrawMsg RPC method.
-              This includes a batch swap message of the batch
+              This response includes a batch swap message of the batch
         '400':
           description: Bad Request
           schema: {}
@@ -2015,7 +2004,7 @@ definitions:
     description: |-
       Coin defines a token with a denomination and an amount.
 
-      NOTE: The amount field is an Int which implements the custom method
+      NOTE: The amount field is an Int that implements the custom method
       signatures required by gogoproto.
   google.protobuf.Any:
     type: object
@@ -2052,7 +2041,7 @@ definitions:
         type: string
         format: int64
         example: '1000'
-        title: height where this message is appended to the batch
+        title: block height when this message is appended to the batch
       msg_index:
         type: string
         format: uint64
@@ -2105,7 +2094,7 @@ definitions:
                 Coin defines a token with a denomination and an amount.
 
 
-                NOTE: The amount field is an Int which implements the custom
+                NOTE: The amount field is an Int that implements the custom
                 method
 
                 signatures required by gogoproto.
@@ -2160,7 +2149,7 @@ definitions:
           description: |-
             Coin defines a token with a denomination and an amount.
 
-            NOTE: The amount field is an Int which implements the custom method
+            NOTE: The amount field is an Int that implements the custom method
             signatures required by gogoproto.
         title: reserve coin pair of the pool to deposit
     description: >-
@@ -2208,7 +2197,7 @@ definitions:
         description: |-
           Coin defines a token with a denomination and an amount.
 
-          NOTE: The amount field is an Int which implements the custom method
+          NOTE: The amount field is an Int that implements the custom method
           signatures required by gogoproto.
         format: sdk.Coin
         example:
@@ -2230,7 +2219,7 @@ definitions:
         description: |-
           Coin defines a token with a denomination and an amount.
 
-          NOTE: The amount field is an Int which implements the custom method
+          NOTE: The amount field is an Int that implements the custom method
           signatures required by gogoproto.
         format: sdk.Coin
         example:
@@ -2266,7 +2255,7 @@ definitions:
 
       You must submit the request using the same fields as the pool
 
-      Only the default `swap_type_id`1 is supported
+      Only the default `swap_type_id` 1 is supported
 
       The detailed swap algorithm is shown here.
 
@@ -2297,7 +2286,7 @@ definitions:
         description: |-
           Coin defines a token with a denomination and an amount.
 
-          NOTE: The amount field is an Int which implements the custom method
+          NOTE: The amount field is an Int that implements the custom method
           signatures required by gogoproto.
         format: sdk.Coin
         example:
@@ -2310,10 +2299,10 @@ definitions:
       Withdraw submit to the batch from the Liquidity pool with the specified
       `pool_id`, `pool_coin` of the pool
 
-      this requests are stacked in the batch of the liquidity pool, not
-      immediately processed and
+      Requests are stacked in the batch of the liquidity pool, they are not
+      immediately processed 
 
-      processed in the `endblock` at once with other requests.
+      Requests are processed in the `endblock` at the same time as other requests.
 
 
       See:
@@ -2397,7 +2386,7 @@ definitions:
           description: |-
             Coin defines a token with a denomination and an amount.
 
-            NOTE: The amount field is an Int which implements the custom method
+            NOTE: The amount field is an Int that implements the custom method
             signatures required by gogoproto.
         description: Fee to create a Liquidity Pool.
       swap_fee_rate:
@@ -2469,7 +2458,7 @@ definitions:
         type: string
         format: int64
         example: '1000'
-        title: height where this batch is begun
+        title: block height when this batch began
       deposit_msg_index:
         type: string
         format: uint64
@@ -2550,7 +2539,7 @@ definitions:
             type: string
             format: int64
             example: '1000'
-            title: height where this batch is begun
+            title: block height when this batch began
           deposit_msg_index:
             type: string
             format: uint64
@@ -2576,7 +2565,7 @@ definitions:
           increments by 1 if the pool id exists.
     description: >-
       the response type for the QueryLiquidityPoolBatchResponse RPC method. It
-      returns the liquidity pool batch corresponding to the requested pool_id.
+      returns the liquidity pool batch that corresponds to the requested pool_id.
   tendermint.liquidity.v1beta1.QueryLiquidityPoolResponse:
     type: object
     properties:
@@ -2614,7 +2603,7 @@ definitions:
         title: The liquidity pool information
     description: >-
       the response type for the QueryLiquidityPoolResponse RPC method. It
-      returns the liquidity pool corresponding to the requested pool_id.
+      returns the liquidity pool that corresponds to the requested pool_id.
   tendermint.liquidity.v1beta1.QueryLiquidityPoolsResponse:
     type: object
     properties:
@@ -2675,7 +2664,7 @@ definitions:
     description: >-
       the response type for the QueryLiquidityPoolsResponse RPC method. This
       includes list of all liquidity pools currently existed and paging results
-      containing next_key and total count.
+      that contains next_key and total count.
   tendermint.liquidity.v1beta1.QueryParamsResponse:
     type: object
     properties:
@@ -2760,7 +2749,7 @@ definitions:
                 Coin defines a token with a denomination and an amount.
 
 
-                NOTE: The amount field is an Int which implements the custom
+                NOTE: The amount field is an Int that implements the custom
                 method
 
                 signatures required by gogoproto.
@@ -2786,8 +2775,7 @@ definitions:
             example: '1'
             title: The smallest unit batch height for every liquidity pool
     description: >-
-      the response type for the QueryParamsResponse RPC method. This includes
-      current parameter of the liquidity module.
+      The response type for the QueryParamsResponse RPC method. This response  includes the current parameter of the liquidity module.
   tendermint.liquidity.v1beta1.QueryPoolBatchDepositMsgResponse:
     type: object
     properties:
@@ -2798,7 +2786,7 @@ definitions:
             type: string
             format: int64
             example: '1000'
-            title: height where this message is appended to the batch
+            title: block height when this message is appended to the batch
           msg_index:
             type: string
             format: uint64
@@ -2851,7 +2839,7 @@ definitions:
                     Coin defines a token with a denomination and an amount.
 
 
-                    NOTE: The amount field is an Int which implements the custom
+                    NOTE: The amount field is an Int that implements the custom
                     method
 
                     signatures required by gogoproto.
@@ -2890,7 +2878,7 @@ definitions:
               type: string
               format: int64
               example: '1000'
-              title: height where this message is appended to the batch
+              title: block height when this message is appended to the batch
             msg_index:
               type: string
               format: uint64
@@ -2943,7 +2931,7 @@ definitions:
                       Coin defines a token with a denomination and an amount.
 
 
-                      NOTE: The amount field is an Int which implements the
+                      NOTE: The amount field is an Int that implements the
                       custom method
 
                       signatures required by gogoproto.
@@ -2989,9 +2977,9 @@ definitions:
 
               was set, its value is undefined otherwise
     description: >-
-      the response type for the QueryPoolBatchDeposit RPC method. This includes
-      a list of all currently existing deposit messages of the batch and paging
-      results containing next_key and total count.
+      the response type for the QueryPoolBatchDeposit RPC method. This response includes
+      a list of all existing deposit messages of the batch and paging
+      results that contain next_key and total count.
   tendermint.liquidity.v1beta1.QueryPoolBatchSwapMsgResponse:
     type: object
     properties:
@@ -3002,7 +2990,7 @@ definitions:
             type: string
             format: int64
             example: '1000'
-            title: height where this message is appended to the batch
+            title: block height when this message is appended to the batch
           msg_index:
             type: string
             format: uint64
@@ -3040,7 +3028,7 @@ definitions:
               Coin defines a token with a denomination and an amount.
 
 
-              NOTE: The amount field is an Int which implements the custom
+              NOTE: The amount field is an Int that implements the custom
               method
 
               signatures required by gogoproto.
@@ -3060,7 +3048,7 @@ definitions:
               Coin defines a token with a denomination and an amount.
 
 
-              NOTE: The amount field is an Int which implements the custom
+              NOTE: The amount field is an Int that implements the custom
               method
 
               signatures required by gogoproto.
@@ -3080,7 +3068,7 @@ definitions:
               Coin defines a token with a denomination and an amount.
 
 
-              NOTE: The amount field is an Int which implements the custom
+              NOTE: The amount field is an Int that implements the custom
               method
 
               signatures required by gogoproto.
@@ -3120,7 +3108,7 @@ definitions:
                   Coin defines a token with a denomination and an amount.
 
 
-                  NOTE: The amount field is an Int which implements the custom
+                  NOTE: The amount field is an Int that implements the custom
                   method
 
                   signatures required by gogoproto.
@@ -3145,7 +3133,7 @@ definitions:
                   Coin defines a token with a denomination and an amount.
 
 
-                  NOTE: The amount field is an Int which implements the custom
+                  NOTE: The amount field is an Int that implements the custom
                   method
 
                   signatures required by gogoproto.
@@ -3195,7 +3183,7 @@ definitions:
           SwapMsgState defines the state of swap message that contains state
           information as it is processed in the next batch or batches
     title: >-
-      the response type for the QueryPoolBatchSwapMsg RPC method. This includes
+      the response type for the QueryPoolBatchSwapMsg RPC method. This response includes
       a batch swap message of the batch
   tendermint.liquidity.v1beta1.QueryPoolBatchSwapMsgsResponse:
     type: object
@@ -3209,7 +3197,7 @@ definitions:
               type: string
               format: int64
               example: '1000'
-              title: height where this message is appended to the batch
+              title: block height when this message is appended to the batch
             msg_index:
               type: string
               format: uint64
@@ -3247,7 +3235,7 @@ definitions:
                 Coin defines a token with a denomination and an amount.
 
 
-                NOTE: The amount field is an Int which implements the custom
+                NOTE: The amount field is an Int that implements the custom
                 method
 
                 signatures required by gogoproto.
@@ -3267,7 +3255,7 @@ definitions:
                 Coin defines a token with a denomination and an amount.
 
 
-                NOTE: The amount field is an Int which implements the custom
+                NOTE: The amount field is an Int that implements the custom
                 method
 
                 signatures required by gogoproto.
@@ -3287,7 +3275,7 @@ definitions:
                 Coin defines a token with a denomination and an amount.
 
 
-                NOTE: The amount field is an Int which implements the custom
+                NOTE: The amount field is an Int that implements the custom
                 method
 
                 signatures required by gogoproto.
@@ -3327,7 +3315,7 @@ definitions:
                     Coin defines a token with a denomination and an amount.
 
 
-                    NOTE: The amount field is an Int which implements the custom
+                    NOTE: The amount field is an Int that implements the custom
                     method
 
                     signatures required by gogoproto.
@@ -3352,7 +3340,7 @@ definitions:
                     Coin defines a token with a denomination and an amount.
 
 
-                    NOTE: The amount field is an Int which implements the custom
+                    NOTE: The amount field is an Int that implements the custom
                     method
 
                     signatures required by gogoproto.
@@ -3422,9 +3410,9 @@ definitions:
 
               was set, its value is undefined otherwise
     description: >-
-      the response type for the QueryPoolBatchSwapMsgs RPC method. This includes
-      list of all currently existing swap messages of the batch and paging
-      results containing next_key and total count.
+      the response type for the QueryPoolBatchSwapMsgs RPC method. This response includes a
+      list of all existing swap messages of the batch and paging
+      results that contain next_key and total count.
   tendermint.liquidity.v1beta1.QueryPoolBatchWithdrawMsgResponse:
     type: object
     properties:
@@ -3435,7 +3423,7 @@ definitions:
             type: string
             format: int64
             example: '1000'
-            title: height where this message is appended to the batch
+            title: block height when this message is appended to the batch
           msg_index:
             type: string
             format: uint64
@@ -3480,7 +3468,7 @@ definitions:
                   Coin defines a token with a denomination and an amount.
 
 
-                  NOTE: The amount field is an Int which implements the custom
+                  NOTE: The amount field is an Int that implements the custom
                   method
 
                   signatures required by gogoproto.
@@ -3523,7 +3511,7 @@ definitions:
               type: string
               format: int64
               example: '1000'
-              title: height where this message is appended to the batch
+              title: block height when this message is appended to the batch
             msg_index:
               type: string
               format: uint64
@@ -3568,7 +3556,7 @@ definitions:
                     Coin defines a token with a denomination and an amount.
 
 
-                    NOTE: The amount field is an Int which implements the custom
+                    NOTE: The amount field is an Int that implements the custom
                     method
 
                     signatures required by gogoproto.
@@ -3617,9 +3605,9 @@ definitions:
 
               was set, its value is undefined otherwise
     description: >-
-      the response type for the QueryPoolBatchWithdraw RPC method. This includes
+      the response type for the QueryPoolBatchWithdraw RPC method. This response includes
       a list of all currently existing withdraw messages of the batch and paging
-      results containing next_key and total count.
+      results that contains next_key and total count.
   tendermint.liquidity.v1beta1.SwapMsgState:
     type: object
     properties:
@@ -3627,7 +3615,7 @@ definitions:
         type: string
         format: int64
         example: '1000'
-        title: height where this message is appended to the batch
+        title: block height when this message is appended to the batch
       msg_index:
         type: string
         format: uint64
@@ -3664,7 +3652,7 @@ definitions:
         description: |-
           Coin defines a token with a denomination and an amount.
 
-          NOTE: The amount field is an Int which implements the custom method
+          NOTE: The amount field is an Int that implements the custom method
           signatures required by gogoproto.
         format: sdk.Coin
         example:
@@ -3681,7 +3669,7 @@ definitions:
         description: |-
           Coin defines a token with a denomination and an amount.
 
-          NOTE: The amount field is an Int which implements the custom method
+          NOTE: The amount field is an Int that implements the custom method
           signatures required by gogoproto.
         format: sdk.Coin
         example:
@@ -3698,7 +3686,7 @@ definitions:
         description: |-
           Coin defines a token with a denomination and an amount.
 
-          NOTE: The amount field is an Int which implements the custom method
+          NOTE: The amount field is an Int that implements the custom method
           signatures required by gogoproto.
         format: sdk.Coin
         example:
@@ -3736,7 +3724,7 @@ definitions:
               Coin defines a token with a denomination and an amount.
 
 
-              NOTE: The amount field is an Int which implements the custom
+              NOTE: The amount field is an Int that implements the custom
               method
 
               signatures required by gogoproto.
@@ -3761,7 +3749,7 @@ definitions:
               Coin defines a token with a denomination and an amount.
 
 
-              NOTE: The amount field is an Int which implements the custom
+              NOTE: The amount field is an Int that implements the custom
               method
 
               signatures required by gogoproto.
@@ -3817,7 +3805,7 @@ definitions:
         type: string
         format: int64
         example: '1000'
-        title: height where this message is appended to the batch
+        title: block height when this message is appended to the batch
       msg_index:
         type: string
         format: uint64
@@ -3862,7 +3850,7 @@ definitions:
               Coin defines a token with a denomination and an amount.
 
 
-              NOTE: The amount field is an Int which implements the custom
+              NOTE: The amount field is an Int that implements the custom
               method
 
               signatures required by gogoproto.

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -3015,7 +3015,7 @@ definitions:
             format: int64
             example: '1000'
             title: >-
-              swap orders are cancelled when current height is equal or higher
+              swap orders are cancelled when current height is equal to or higher
               than ExpiryHeight
           exchanged_offer_coin:
             type: object
@@ -3222,7 +3222,7 @@ definitions:
               format: int64
               example: '1000'
               title: >-
-                swap orders are cancelled when current height is equal or higher
+                swap orders are cancelled when current height is equal to or higher
                 than ExpiryHeight
             exchanged_offer_coin:
               type: object
@@ -3640,7 +3640,7 @@ definitions:
         format: int64
         example: '1000'
         title: >-
-          swap orders are cancelled when current height is equal or higher than
+          swap orders are cancelled when current height is equal to or higher than
           ExpiryHeight
       exchanged_offer_coin:
         type: object

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -98,9 +98,7 @@ paths:
 
 
                         NOTE: The amount field is an Int that implements the
-                        custom method
-
-                        signatures required by gogoproto.
+                        custom method signatures required by gogoproto.
                     description: Fee to create a Liquidity Pool
                   swap_fee_rate:
                     type: string
@@ -218,9 +216,7 @@ paths:
                     format: uint64
                     title: >-
                       total is total number of results available if
-                      PageRequest.count_total
-
-                      was set, its value is undefined otherwise
+                      PageRequest.count_total was set, its value is undefined otherwise
             description: >-
               The response type for the QueryLiquidityPoolsResponse RPC method.
               This response includes a list of all existing liquidity pools and
@@ -601,13 +597,13 @@ paths:
                       description: >-
                         `MsgDepositWithinBatch defines` an `sdk.Msg` type that
                         supports submitting a deposit requests to the liquidity
-                        pool batch
+                        pool batch.
 
                         The deposit is submitted with the specified `pool_id`
-                        and reserve `deposit_coins`
+                        and reserve `deposit_coins`.
 
                         The deposit requests are stacked in the liquidity pool
-                        batch and are not immediately processed
+                        batch and are not immediately processed.
 
                         Batch deposit requests are processed in the `endblock`
                         at the same time as other requests.
@@ -621,8 +617,7 @@ paths:
                     the next batch or batches
               pagination:
                 description: >-
-                  pagination defines the pagination in the response. not working
-                  on this version.
+                  pagination defines the pagination in the response. Not supported in this version.
                 type: object
                 properties:
                   next_key:
@@ -695,8 +690,7 @@ paths:
         - name: pagination.key
           description: |-
             key is a value returned in PageResponse.next_key to begin
-            querying the next page most efficiently. Only one of offset or key
-            should be set.
+            querying the next page most efficiently. Set only one of offset or key.
           in: query
           required: false
           type: string
@@ -705,10 +699,7 @@ paths:
           description: >-
             offset is a numeric offset that can be used when key is unavailable.
 
-            It is less efficient than using key. Only one of offset or key
-            should
-
-            be set.
+            Offset is less efficient than using key. Set only one of offset or key.
           in: query
           required: false
           type: string
@@ -731,7 +722,7 @@ paths:
             a count of the total number of items available for pagination in
             UIs.
 
-            count_total is only respected when offset is used. It is ignored
+            count_total is respected only when offset is used. count_total is ignored
             when key
 
             is set.
@@ -827,13 +818,13 @@ paths:
                     description: >-
                       `MsgDepositWithinBatch defines` an `sdk.Msg` type that
                       supports submitting a deposit requests to the liquidity
-                      pool batch
+                      pool batch.
 
                       The deposit is submitted with the specified `pool_id` and
-                      reserve `deposit_coins`
+                      reserve `deposit_coins`.
 
                       The deposit requests are stacked in the liquidity pool
-                      batch and are not immediately processed
+                      batch and are not immediately processed.
 
                       Batch deposit requests are processed in the `endblock` at
                       the same time as other requests.
@@ -1101,25 +1092,25 @@ paths:
                             are sorted alphabetically
                       description: >-
                         `MsgSwapWithinBatch` defines an sdk.Msg type that
-                        submits a swap offer request to the liquidity pool batch
+                        submits a swap offer request to the liquidity pool batch.
 
                         Submit swap offer to the liquidity pool batch with the
                         specified the `pool_id`, `swap_type_id`,
 
                         `demand_coin_denom` with the coin and the price you're
-                        offering
+                        offering.
 
                         The `offer_coin_fee` must be half of the offer coin
                         amount * current `params.swap_fee_rate` for reservation
-                        to pay fees
+                        to pay fees.
 
                         This request is added to the pool and executed at the
-                        end of the batch (`endblock`)
+                        end of the batch (`endblock`).
 
                         You must submit the request using the same fields as the
-                        pool
+                        pool.
 
-                        Only the default `swap_type_id`1 is supported
+                        Only the default `swap_type_id`1 is supported.
 
                         The detailed swap algorithm is shown here.
 
@@ -1238,7 +1229,7 @@ paths:
           format: uint64
         - name: pagination.count_total
           description: >-
-            count_total is set to true  to indicate that the result set should
+            count_total is set to true to indicate that the result set should
             include
 
             a count of the total number of items available for pagination in
@@ -1261,7 +1252,7 @@ paths:
       summary: Get specific swap message in the pool's current batch.
       description: >-
         Returns the swap message that corresponds to the msg_index in the pool's
-        current batch
+        current batch.
       operationId: PoolBatchSwapMsg
       responses:
         '200':
@@ -1446,25 +1437,25 @@ paths:
                           are sorted alphabetically
                     description: >-
                       `MsgSwapWithinBatch` defines an sdk.Msg type that submits
-                      a swap offer request to the liquidity pool batch
+                      a swap offer request to the liquidity pool batch.
 
                       Submit swap offer to the liquidity pool batch with the
                       specified the `pool_id`, `swap_type_id`,
 
                       `demand_coin_denom` with the coin and the price you're
-                      offering
+                      offering.
 
                       The `offer_coin_fee` must be half of the offer coin amount
                       * current `params.swap_fee_rate` for reservation to pay
-                      fees
+                      fees.
 
                       This request is added to the pool and executed at the end
                       of the batch (`endblock`)
 
                       You must submit the request using the same fields as the
-                      pool
+                      pool.
 
-                      Only the default `swap_type_id`1 is supported
+                      Only the default `swap_type_id`1 is supported.
 
                       The detailed swap algorithm is shown here.
 
@@ -1624,15 +1615,13 @@ paths:
                             amount: '1000'
                       description: >-
                         `MsgWithdrawWithinBatch` defines an `sdk.Msg` type that
-                        submits a withdraw request to the liquidity pool batch
+                        submits a withdraw request to the liquidity pool batch.
 
                         Withdraw submit to the batch from the Liquidity pool
-                        with the specified `pool_id`, `pool_coin` of the pool
+                        with the specified `pool_id`, `pool_coin` of the pool.
 
-                        this requests are stacked in the batch of the liquidity
-                        pool, not immediately processed and
-
-                        processed in the `endblock` at once with other requests.
+                        This request is stacked in the batch of the liquidity
+                        pool and is not immediately processed. Batch withdraw requests are processed in the `endblock` at the same time as other requests.
 
 
                         See:
@@ -1844,15 +1833,13 @@ paths:
                           amount: '1000'
                     description: >-
                       `MsgWithdrawWithinBatch` defines an `sdk.Msg` type that
-                      submits a withdraw request to the liquidity pool batch
+                      submits a withdraw request to the liquidity pool batch.
 
                       Withdraw submit to the batch from the Liquidity pool with
-                      the specified `pool_id`, `pool_coin` of the pool
+                      the specified `pool_id`, `pool_coin` of the pool.
 
-                      this requests are stacked in the batch of the liquidity
-                      pool, not immediately processed and
-
-                      processed in the `endblock` at once with other requests.
+                      This request is stacked in the batch of the liquidity
+                      pool and is not immediately processed. Batch withdraw requests are processed in the `endblock` at the same time as other requests.
 
 
                       See:
@@ -2101,13 +2088,13 @@ definitions:
             title: reserve coin pair of the pool to deposit
         description: >-
           `MsgDepositWithinBatch defines` an `sdk.Msg` type that supports
-          submitting a deposit requests to the liquidity pool batch
+          submitting a deposit request to the liquidity pool batch.
 
           The deposit is submitted with the specified `pool_id` and reserve
-          `deposit_coins`
+          `deposit_coins`.
 
           The deposit requests are stacked in the liquidity pool batch and are
-          not immediately processed
+          not immediately processed.
 
           Batch deposit requests are processed in the `endblock` at the same
           time as other requests.
@@ -2154,13 +2141,13 @@ definitions:
         title: reserve coin pair of the pool to deposit
     description: >-
       `MsgDepositWithinBatch defines` an `sdk.Msg` type that supports submitting
-      a deposit requests to the liquidity pool batch
+      a deposit request to the liquidity pool batch.
 
       The deposit is submitted with the specified `pool_id` and reserve
-      `deposit_coins`
+      `deposit_coins`.
 
       The deposit requests are stacked in the liquidity pool batch and are not
-      immediately processed
+      immediately processed.
 
       Batch deposit requests are processed in the `endblock` at the same time as
       other requests.
@@ -2294,13 +2281,13 @@ definitions:
           amount: '1000'
     description: >-
       `MsgWithdrawWithinBatch` defines an `sdk.Msg` type that submits a withdraw
-      request to the liquidity pool batch
+      request to the liquidity pool batch.
 
       Withdraw submit to the batch from the Liquidity pool with the specified
-      `pool_id`, `pool_coin` of the pool
+      `pool_id`, `pool_coin` of the pool.
 
       Requests are stacked in the batch of the liquidity pool, they are not
-      immediately processed 
+      immediately processed.
 
       Requests are processed in the `endblock` at the same time as other requests.
 
@@ -2321,7 +2308,7 @@ definitions:
               example: '1'
               title: >-
                 The id of the pool_type to use as pool_type_id for pool
-                creation.
+                creation
 
                 Only pool-type-id 1 is supported
 
@@ -2846,13 +2833,13 @@ definitions:
                 title: reserve coin pair of the pool to deposit
             description: >-
               `MsgDepositWithinBatch defines` an `sdk.Msg` type that supports
-              submitting a deposit requests to the liquidity pool batch
+              submitting a deposit request to the liquidity pool batch.
 
               The deposit is submitted with the specified `pool_id` and reserve
-              `deposit_coins`
+              `deposit_coins`.
 
               The deposit requests are stacked in the liquidity pool batch and
-              are not immediately processed
+              are not immediately processed.
 
               Batch deposit requests are processed in the `endblock` at the same
               time as other requests.
@@ -2938,13 +2925,13 @@ definitions:
                   title: reserve coin pair of the pool to deposit
               description: >-
                 `MsgDepositWithinBatch defines` an `sdk.Msg` type that supports
-                submitting a deposit requests to the liquidity pool batch
+                submitting a deposit request to the liquidity pool batch.
 
                 The deposit is submitted with the specified `pool_id` and
-                reserve `deposit_coins`
+                reserve `deposit_coins`.
 
                 The deposit requests are stacked in the liquidity pool batch and
-                are not immediately processed
+                are not immediately processed.
 
                 Batch deposit requests are processed in the `endblock` at the
                 same time as other requests.
@@ -3479,15 +3466,13 @@ definitions:
                   amount: '1000'
             description: >-
               `MsgWithdrawWithinBatch` defines an `sdk.Msg` type that submits a
-              withdraw request to the liquidity pool batch
+              withdraw request to the liquidity pool batch.
 
               Withdraw submit to the batch from the Liquidity pool with the
-              specified `pool_id`, `pool_coin` of the pool
+              specified `pool_id`, `pool_coin` of the pool.
 
-              this requests are stacked in the batch of the liquidity pool, not
-              immediately processed and
-
-              processed in the `endblock` at once with other requests.
+              The requests are stacked in the liquidity pool batch and are
+          not immediately processed. Withdraw requests are processed in the `endblock` at the same time as other requests.
 
 
               See:
@@ -3567,15 +3552,12 @@ definitions:
                     amount: '1000'
               description: >-
                 `MsgWithdrawWithinBatch` defines an `sdk.Msg` type that submits
-                a withdraw request to the liquidity pool batch
+                a withdraw request to the liquidity pool batch.
 
                 Withdraw submit to the batch from the Liquidity pool with the
-                specified `pool_id`, `pool_coin` of the pool
+                specified `pool_id`, `pool_coin` of the pool.
 
-                this requests are stacked in the batch of the liquidity pool,
-                not immediately processed and
-
-                processed in the `endblock` at once with other requests.
+                This request is stacked in the batch of the liquidity pool and is not immediately processed. This request is processed in the `endblock` at the same time as other requests.
 
 
                 See:
@@ -3861,15 +3843,13 @@ definitions:
               amount: '1000'
         description: >-
           `MsgWithdrawWithinBatch` defines an `sdk.Msg` type that submits a
-          withdraw request to the liquidity pool batch
+          withdraw request to the liquidity pool batch.
 
           Withdraw submit to the batch from the Liquidity pool with the
-          specified `pool_id`, `pool_coin` of the pool
+          specified `pool_id`, `pool_coin` of the pool.
 
-          this requests are stacked in the batch of the liquidity pool, not
-          immediately processed and
-
-          processed in the `endblock` at once with other requests.
+          This request is stacked in the batch of the liquidity pool and is not
+          immediately processed. The request is processed in the `endblock` at the same time as other requests.
 
 
           See:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

swagger.yaml edits for liquidity module

question: do we want a message description for block heights to be "is" or "was"
in this PR, I am suggesting to use present tense (although I was tempted to use the past tense, I don't know enough yet to make a firm recommendation)

I think that we are recording the block height "when this message _was_ appended" ?? 

> title: block height when this message is appended to the batch

closes: part of https://github.com/tendermint/liquidity/pull/217
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
