### PR TITLE
Correct usage of Mul/Quo and Mul/QuoTruncate

### DIFF
--- a/x/liquidity/keeper/liquidity_pool.go
+++ b/x/liquidity/keeper/liquidity_pool.go
@@ -147,7 +147,7 @@ func (k Keeper) CreatePool(ctx sdk.Context, msg *types.MsgCreatePool) (types.Poo
 	k.SetPoolBatch(ctx, batch)
 
 	reserveCoins := k.GetReserveCoins(ctx, pool)
-	lastReserveRatio := sdk.NewDecFromInt(reserveCoins[0].Amount).QuoTruncate(sdk.NewDecFromInt(reserveCoins[1].Amount))
+	lastReserveRatio := sdk.NewDecFromInt(reserveCoins[0].Amount).Quo(sdk.NewDecFromInt(reserveCoins[1].Amount))
 	logger := k.Logger(ctx)
 	logger.Debug(
 		"create liquidity pool",
@@ -196,7 +196,6 @@ func (k Keeper) DepositLiquidityPool(ctx sdk.Context, msg types.DepositMsgState,
 				return types.ErrLessThanMinInitDeposit
 			}
 		}
-
 		poolCoin, err := k.MintAndSendPoolCoin(ctx, pool, batchEscrowAcc, depositor, msg.Msg.DepositCoins)
 		if err != nil {
 			return err
@@ -210,7 +209,7 @@ func (k Keeper) DepositLiquidityPool(ctx sdk.Context, msg types.DepositMsgState,
 		reserveCoins = k.GetReserveCoins(ctx, pool)
 		lastReserveCoinA := sdk.NewDecFromInt(reserveCoins[0].Amount)
 		lastReserveCoinB := sdk.NewDecFromInt(reserveCoins[1].Amount)
-		lastReserveRatio := lastReserveCoinA.QuoTruncate(lastReserveCoinB)
+		lastReserveRatio := lastReserveCoinA.Quo(lastReserveCoinB)
 		ctx.EventManager().EmitEvent(
 			sdk.NewEvent(
 				types.EventTypeDepositToPool,
@@ -298,8 +297,8 @@ func (k Keeper) DepositLiquidityPool(ctx sdk.Context, msg types.DepositMsgState,
 	// calculate pool token mint amount
 	poolCoinTotalSupply := k.GetPoolCoinTotalSupply(ctx, pool)
 	poolCoinAmt := sdk.MinInt(
-		poolCoinTotalSupply.ToDec().Mul(depositCoinAmountA.ToDec()).Quo(reserveCoins[0].Amount.ToDec()).TruncateInt(),
-		poolCoinTotalSupply.ToDec().Mul(depositCoinAmountB.ToDec()).Quo(reserveCoins[1].Amount.ToDec()).TruncateInt())
+		poolCoinTotalSupply.ToDec().MulTruncate(depositCoinAmountA.ToDec()).QuoTruncate(reserveCoins[0].Amount.ToDec()).TruncateInt(),
+		poolCoinTotalSupply.ToDec().MulTruncate(depositCoinAmountB.ToDec()).QuoTruncate(reserveCoins[1].Amount.ToDec()).TruncateInt())
 	mintPoolCoin := sdk.NewCoin(pool.PoolCoinDenom, poolCoinAmt)
 	mintPoolCoins := sdk.NewCoins(mintPoolCoin)
 
@@ -347,7 +346,7 @@ func (k Keeper) DepositLiquidityPool(ctx sdk.Context, msg types.DepositMsgState,
 	)
 
 	reserveCoins = k.GetReserveCoins(ctx, pool)
-	lastReserveRatio = sdk.NewDecFromInt(reserveCoins[0].Amount).QuoTruncate(sdk.NewDecFromInt(reserveCoins[1].Amount))
+	lastReserveRatio = sdk.NewDecFromInt(reserveCoins[0].Amount).Quo(sdk.NewDecFromInt(reserveCoins[1].Amount))
 
 	logger := k.Logger(ctx)
 	logger.Debug(
@@ -475,7 +474,7 @@ func (k Keeper) WithdrawLiquidityPool(ctx sdk.Context, msg types.WithdrawMsgStat
 	if reserveCoins.IsZero() {
 		lastReserveRatio = sdk.ZeroDec()
 	} else {
-		lastReserveRatio = sdk.NewDecFromInt(reserveCoins[0].Amount).QuoTruncate(sdk.NewDecFromInt(reserveCoins[1].Amount))
+		lastReserveRatio = sdk.NewDecFromInt(reserveCoins[0].Amount).Quo(sdk.NewDecFromInt(reserveCoins[1].Amount))
 	}
 
 	logger := k.Logger(ctx)

--- a/x/liquidity/keeper/liquidity_pool_test.go
+++ b/x/liquidity/keeper/liquidity_pool_test.go
@@ -847,8 +847,8 @@ func TestDepositWithCoinsSent(t *testing.T) {
 	require.NoError(t, err)
 	reserveCoins := simapp.LiquidityKeeper.GetReserveCoins(ctx, pool)
 	require.Len(t, reserveCoins, 2) // denomZ coins are ignored
-	require.True(sdk.IntEq(t, reserveCoins.AmountOf(DenomX), sdk.NewInt(2000000)))
-	require.True(sdk.IntEq(t, reserveCoins.AmountOf(DenomY), sdk.NewInt(3000000)))
+	require.True(sdk.IntEq(t, sdk.NewInt(2000000), reserveCoins.AmountOf(DenomX)))
+	require.True(sdk.IntEq(t, sdk.NewInt(3000000), reserveCoins.AmountOf(DenomY)))
 
 	// Add more coins to deposit.
 	depositCoins := sdk.NewCoins(sdk.NewInt64Coin(DenomX, 3000000), sdk.NewInt64Coin(DenomY, 3000000))
@@ -861,10 +861,10 @@ func TestDepositWithCoinsSent(t *testing.T) {
 	liquidity.EndBlocker(ctx, simapp.LiquidityKeeper)
 
 	reserveCoins = simapp.LiquidityKeeper.GetReserveCoins(ctx, pool)
-	require.True(sdk.IntEq(t, reserveCoins.AmountOf(DenomX), sdk.NewInt(3999999))) // This is because of decimal truncation error.
-	require.True(sdk.IntEq(t, reserveCoins.AmountOf(DenomY), sdk.NewInt(6000000)))
+	require.True(sdk.IntEq(t, sdk.NewInt(3999999), reserveCoins.AmountOf(DenomX))) // This is because of decimal truncation error.
+	require.True(sdk.IntEq(t, sdk.NewInt(6000000), reserveCoins.AmountOf(DenomY)))
 	balances := simapp.BankKeeper.GetAllBalances(ctx, addr)
-	require.True(sdk.IntEq(t, balances.AmountOf(DenomX), sdk.NewInt(1000001)))
-	require.True(sdk.IntEq(t, balances.AmountOf(DenomY), sdk.NewInt(0)))
-	require.True(sdk.IntEq(t, balances.AmountOf(pool.PoolCoinDenom), sdk.NewInt(999999)))
+	require.True(sdk.IntEq(t, sdk.NewInt(1000001), balances.AmountOf(DenomX)))
+	require.True(sdk.IntEq(t, sdk.NewInt(0), balances.AmountOf(DenomY)))
+	require.True(sdk.IntEq(t, sdk.NewInt(999999), balances.AmountOf(pool.PoolCoinDenom)))
 }


### PR DESCRIPTION


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- use Mul/Quo for pool price(reserve ratio)
- use *Truncate for minting pool coin amount

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #380

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
